### PR TITLE
update types of vertexId and vertexValue to byte

### DIFF
--- a/proto/scenario.proto
+++ b/proto/scenario.proto
@@ -1,8 +1,8 @@
 package stanford.infolab.debugger;
 
 message GiraphScenario {
-  required int64 vertexId = 1;
-  repeated int64 nbrs = 2;
+  required bytes vertexId = 1;
+  repeated bytes nbrs = 2;
   required bytes vertexValue = 3;
   repeated bytes messages = 4;
 }


### PR DESCRIPTION
It's a strong assumption that vertexId is always integer and vertexValue is always string
