### PR TITLE
Caching jars when launching jobs for later

### DIFF
--- a/giraph-debug
+++ b/giraph-debug
@@ -71,6 +71,8 @@ set -eu
 # some defaults
 : ${TRACE_ROOT:=/giraph-debug-traces} # HDFS path to where the traces are stored
 : ${CLASSNAME_SUFFIX:=Original}       # A suffix for user computation class used by instrumenter
+: ${JARCACHE_HDFS:=$TRACE_ROOT/jars}         # HDFS path to where the jars are cached
+: ${JARCACHE_LOCAL:=~/.giraph-debugger/jars} # local path to where the jars are cached
 
 error() { echo >&2 "$@"; false; }
 usage() {
@@ -92,6 +94,19 @@ javaOpts=(
     -D"giraph.debugger.traceRootAtHDFS=$TRACE_ROOT" # pass the TRACE_ROOT at HDFS
 )
 exec_java() { exec java -cp "$CLASSPATH" "${javaOpts[@]}" "$@"; }
+exec_java_command_line() {
+    local jobId=${2:-}
+    if [ -n "$jobId" ] &&
+        jarFileSig=$(hadoop fs -cat "$TRACE_ROOT"/"$jobId"/jar.signature); then
+        # get a copy of the job's jar in local cache if necessary
+        mkdir -p "$JARCACHE_LOCAL"
+        jarFileCachedLocal="$JARCACHE_LOCAL"/"$jarFileSig".jar
+        [ -e "$jarFileCachedLocal" ] ||
+            hadoop fs -get "$JARCACHE_HDFS"/"$jarFileSig".jar "$jarFileCachedLocal"
+        CLASSPATH="$jarFileCachedLocal:$CLASSPATH"
+    fi
+    exec_java org.apache.giraph.debugger.CommandLine "$@"
+}
 
 # handle modes other than launching GiraphJob first
 case $1 in
@@ -107,11 +122,12 @@ case $1 in
         shift
         if [ $# -gt 0 ]; then
             JobId=$1; shift
-            exec_java org.apache.giraph.debugger.CommandLine list \
+            exec_java_command_line list \
                 "$JobId" "$@"
         else
             set -o pipefail
             hadoop fs -ls "$TRACE_ROOT" |
+            grep -v "$JARCACHE_HDFS" |
             tail -n +2 | sed 's:.*/:list  :'
             exit $?
         fi
@@ -125,7 +141,7 @@ case $1 in
         Superstep=$1; shift
         [ $# -gt 0 ] || usage "VERTEX_ID to dump is missing"
         VertexId=$1; shift
-        exec_java org.apache.giraph.debugger.CommandLine dump \
+        exec_java_command_line dump \
             "$JobId" "$Superstep" "$VertexId" "$@"
         ;;
 
@@ -139,7 +155,7 @@ case $1 in
         VertexId=$1; shift
         [ $# -gt 0 ] || usage "TEST_NAME prefix for output is missing"
         TestName=$1; shift
-        exec_java org.apache.giraph.debugger.CommandLine mktest \
+        exec_java_command_line mktest \
             "$JobId" "$Superstep" "$VertexId" "$TestName" "$@"
         ;;
 
@@ -151,7 +167,7 @@ case $1 in
         Superstep=$1; shift
         [ $# -gt 0 ] || usage "TEST_NAME prefix for output is missing"
         TestName=$1; shift
-        exec_java org.apache.giraph.debugger.CommandLine mktest-master \
+        exec_java_command_line mktest-master \
             "$JobId" "$Superstep" "$TestName" "$@"
         ;;
 
@@ -288,6 +304,25 @@ runJar=$instrumentedJarFile
 #jar cf "$instrumentedJarFile" -C "$tmpDir"/classes .
 #runJar=$jarFile
 #hadoopJarOpts+=(-libjars "$instrumentedJarFile")
+
+# keep the submitted jar file around, in order to read the captured traces later
+jarFileSig=$( (sha1sum || shasum) <"$jarFile" 2>/dev/null)
+jarFileSig=${jarFileSig%%[[:space:]]*}
+jarFileCachedLocal="$JARCACHE_LOCAL"/"$jarFileSig".jar
+jarFileCachedHDFS="$JARCACHE_HDFS"/"$jarFileSig".jar
+echo >&2 "Caching the job jar locally: $jarFileCachedLocal"
+[ -e "$jarFileCachedLocal" ] || {
+    mkdir -p "$(dirname "$jarFileCachedLocal")"
+    ln -f "$jarFile" "$jarFileCachedLocal" ||
+        cp -f "$jarFile" "$jarFileCachedLocal"
+}
+echo >&2 "Caching the job jar at HDFS: $jarFileCachedHDFS"
+hadoop fs -test -e "$jarFileCachedHDFS" || {
+    hadoop fs -mkdir "$(dirname "$jarFileCachedHDFS")"
+    hadoop fs -put "$jarFile" "$jarFileCachedHDFS"
+}
+# let AbstractInterceptingComputation record the jar signature under the job trace dir
+hadoopJarOpts+=(-D"giraph.debugger.jarSignature=$jarFileSig")
 
 # submit a job to run the new instrumented jar with the original
 HADOOP_CLASSPATH="$runJar:$HADOOP_CLASSPATH" \

--- a/src/main/java/org/apache/giraph/debugger/gui/ServerUtils.java
+++ b/src/main/java/org/apache/giraph/debugger/gui/ServerUtils.java
@@ -128,6 +128,12 @@ public class ServerUtils {
     }
   }
 
+  public static String getCachedJobJarPath(String jobId) {
+    // TODO read the "jar.signature" file under the TRACE_ROOT/jobId
+    // TODO then return the path: TRACE_ROOT/jars/jarSignature
+    return null;
+  }
+  
   /*
    * Returns the path of the vertex trace file on HDFS.
    * @param debugTrace - Must be one of VERTEX_* types. 
@@ -184,6 +190,8 @@ public class ServerUtils {
       throw new IllegalArgumentException(
         "DebugTrace type is invalid. Use REGULAR, EXCEPTION or ALL_VERTICES");
     }
+    // TODO Before loading any trace, add the job jar at getCachedJobJarPath() to the ClassLoader's CLASSPATH.
+    // TODO Alternatively, the GUI can tell the Server to augment the CLASSPATH whenever it's told to load a new job id, because CLASSPATH for command-line operations are completely handled by the giraph-debug script.
     FileSystem fs = ServerUtils.getFileSystem();
     GiraphVertexScenarioWrapper giraphScenarioWrapper = new GiraphVertexScenarioWrapper();
     // If debugTrace is regular or null, try reading the regular trace first.


### PR DESCRIPTION
User's classes have to be on CLASSPATH when the debugger tries to read
the captured traces later.
- locally it caches at `~/.giraph-debugger/jars/` (or under $JARCACHE_LOCAL/)
- on HDFS, it caches at `$TRACE_ROOT/jars/` (or under $JARCACHE_HDFS/)

The signature of the jar corresponding to a job is recorded in
`jar.signature` in the trace dir, e.g.,
`/giraph-debug-traces/job_201405271720_0008/jar.signature`.
This is recorded by the AbstractInterceptingComputation that first
finishes initializing, and read by giraph-debug script later to be put
on the local jar cache.

Known bug: GUI server isn't taking care of the class path, so it's
unable to load the traces, unless it was launched with the CLASSPATH
carefully set to include user's classes.
