### PR TITLE
Fixed GUI Server to load cached job jars

### DIFF
--- a/src/main/java/org/apache/giraph/debugger/utils/BaseWrapper.java
+++ b/src/main/java/org/apache/giraph/debugger/utils/BaseWrapper.java
@@ -6,6 +6,10 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.net.URLClassLoader;
 
 import org.apache.giraph.utils.ReflectionUtils;
 import org.apache.giraph.utils.WritableUtils;
@@ -101,4 +105,51 @@ public abstract class BaseWrapper {
 
   public abstract void loadFromProto(GeneratedMessage protoObject) throws ClassNotFoundException,
     IOException, InstantiationException, IllegalAccessException;
+  
+  /**
+   * Add given URLs to the CLASSPATH before loading from HDFS. To do so, we hack
+   * the system class loader, assuming it is an URLClassLoader.
+   * 
+   * XXX Setting the currentThread's context class loader has no effect on
+   * Class#forName().
+   * 
+   * @see http://stackoverflow.com/a/12963811/390044
+   * @param fs
+   * @param fileName
+   * @param classPaths
+   * @throws ClassNotFoundException
+   * @throws InstantiationException
+   * @throws IllegalAccessException
+   * @throws IOException
+   */
+  public void loadFromHDFS(FileSystem fs, String fileName, URL... classPaths)
+    throws ClassNotFoundException, InstantiationException, IllegalAccessException, IOException {
+    for (URL url : classPaths)
+      addPath(url);
+    loadFromHDFS(fs, fileName);
+  }
+
+  /**
+   * @param u the URL to add to the CLASSPATH
+   * @see http://stackoverflow.com/a/252967/390044
+   */
+  private static void addPath(URL u) {
+    // need to do add path to Classpath with reflection since the
+    // URLClassLoader.addURL(URL url) method is protected:
+    ClassLoader cl = ClassLoader.getSystemClassLoader();
+    if (cl instanceof URLClassLoader) {
+      URLClassLoader urlClassLoader = (URLClassLoader) cl;
+      Class<URLClassLoader> urlClass = URLClassLoader.class;
+      try {
+        Method method = urlClass.getDeclaredMethod("addURL", new Class[] { URL.class });
+        method.setAccessible(true);
+        method.invoke(urlClassLoader, new Object[] { u });
+      } catch (NoSuchMethodException | SecurityException | IllegalAccessException
+        | IllegalArgumentException | InvocationTargetException e) {
+        throw new IllegalStateException("Cannot add URL to system ClassLoader", e);
+      }
+    } else {
+      throw new IllegalStateException("Cannot add URL to system ClassLoader of type " + cl.getClass().getSimpleName());
+    }
+  }
 }


### PR DESCRIPTION
by hacking the system ClassLoader, assuming it is a URLClassLoader, and
using reflection to call addURL method to add the cached jars.

Known bugs: things could go wrong if user launches jobs with jars that
contain different versions of the same class, then tries to load both
jobs while the server is running.  In such case, user can restart the
GUI server before opening the other job.
