### PR TITLE
Fixing the Capture Scenario break due to last commit and cleaning up the fetchTest functions

### DIFF
--- a/src/main/resources/org/apache/giraph/debugger/gui/index.html
+++ b/src/main/resources/org/apache/giraph/debugger/gui/index.html
@@ -83,9 +83,9 @@
 
 					// Generate Test Graph - Fetch the test graph and display the code.
 					$('#btn-gen-test-graph').click(function() {
-						var ajaxRequest = Utils.fetchTestGraph(giraphDebugger.debuggerServerRoot, Utils.getAdjListStrForTestGraph(giraphDebugger.editor.getAdjList()))
-						ajaxRequest.ajax.done(function(response) {
-							handleTestGraphSuccess({ code: response, url : ajaxRequest.url });
+						Utils.fetchTestGraph(giraphDebugger.debuggerServerRoot, Utils.getAdjListStrForTestGraph(giraphDebugger.editor.getAdjList()))
+						.done(function(response) {
+							handleTestGraphSuccess(response);
 						})
 						.fail(function(responseText) {
 							handleTestGraphFail(responseText);

--- a/src/main/resources/org/apache/giraph/debugger/gui/js/debugger.js
+++ b/src/main/resources/org/apache/giraph/debugger/gui/js/debugger.js
@@ -436,10 +436,10 @@ GiraphDebugger.prototype.initSuperstepControlEvents = function() {
     $(this.btnCaptureVertexScenario).click((function(event){
         // Get the deferred object.
         var vertexId = $(this.captureVertexIdInput).val();
-        var ajaxRequest = Utils.fetchVertexTest(this.debuggerServerRoot, this.currentJobId, 
-            this.currentSuperstepNumber, vertexId, 'reg');
-        ajaxRequest.ajax.done((function(response) {
-            this.onCaptureVertex.done({ code: response, url : ajaxRequest.url });
+        Utils.fetchVertexTest(this.debuggerServerRoot, this.currentJobId, 
+            this.currentSuperstepNumber, vertexId, 'reg')
+        .done((function(response) {
+            this.onCaptureVertex.done(response);
         }).bind(this))
         .fail((function(response) {
             this.onCaptureVertex.fail(response.responseText);
@@ -447,9 +447,9 @@ GiraphDebugger.prototype.initSuperstepControlEvents = function() {
     }).bind(this));
     // Handle the master capture scenario button the superstep controls.
     $(this.btnCaptureMasterScenario).click((function(event){
-        var ajaxRequest = Utils.fetchMasterTest(this.debuggerServerRoot, this.currentJobId, this.currentSuperstepNumber);
-        ajaxRequest.ajax.done((function(response) {
-            this.onCaptureMaster.done({ code: response, url : ajaxRequest.url });
+        Utils.fetchMasterTest(this.debuggerServerRoot, this.currentJobId, this.currentSuperstepNumber)
+        .done((function(response) {
+            this.onCaptureMaster.done(response);
         }).bind(this))
         .fail((function(response) {
             this.onCaptureMaster.fail(response.responseText);
@@ -467,9 +467,9 @@ GiraphDebugger.prototype.initSuperstepControlEvents = function() {
         var graphTypeKey = $(this.selectSampleGraphs).val();
         this.editor.buildGraphFromSimpleAdjList(Utils.sampleGraphs[graphTypeKey](numVertices));
 
-        var ajaxRequest = Utils.fetchTestGraph(this.debuggerServerRoot, Utils.getAdjListStrForTestGraph(this.editor.getAdjList()))
-        ajaxRequest.ajax.done((function(response) {
-            this.onGenerateTestGraph.done({ code : response, url : ajaxRequest.url });
+        Utils.fetchTestGraph(this.debuggerServerRoot, Utils.getAdjListStrForTestGraph(this.editor.getAdjList()))
+        .done((function(response) {
+            this.onGenerateTestGraph.done(response);
         }).bind(this))
         .fail((function(response) {
             this.onGenerateTestGraph.fail(response.responseText);

--- a/src/main/resources/org/apache/giraph/debugger/gui/js/utils.js
+++ b/src/main/resources/org/apache/giraph/debugger/gui/js/utils.js
@@ -131,14 +131,43 @@ Utils.downloadFile = function(contents, fileName) {
  * Utility method to fetch vertex sceario from server.
  */
 Utils.fetchVertexTest = function(debuggerServerRoot, jobId, superstepId, vertexId, traceType) {
+    var url = debuggerServerRoot + '/test/vertex';
+    var params = { 
+        jobId : jobId,
+        superstepId : superstepId,
+        vertexId : vertexId,
+        traceType : traceType
+    };
     return $.ajax({
-            url : debuggerServerRoot + '/test/vertex',
-            data : {
-                jobId : jobId,
-                superstepId : superstepId,
-                vertexId : vertexId,
-                traceType : traceType
-            }
+        url : url, 
+        data : params,
+        dataFilter : function(data) {
+            return {
+                code: data,
+                url : "{0}?{1}".format(url, $.param(params))
+            };
+        }
+    });
+}
+
+/* 
+ * Utility method to fetch master sceario from server.
+ */
+Utils.fetchMasterTest = function(debuggerServerRoot, jobId, superstepId) {
+    var url = debuggerServerRoot + '/test/master';
+    var params = {
+            jobId: jobId,
+            superstepId : superstepId
+    };
+    return $.ajax({
+        url : url,
+        data : params,
+        dataFilter : function(data) {
+            return {
+                code: data,
+                url : "{0}?{1}".format(url, $.param(params))
+            };
+        }
     });
 }
 
@@ -146,9 +175,17 @@ Utils.fetchVertexTest = function(debuggerServerRoot, jobId, superstepId, vertexI
  * Utility method to fetch the test graph for an adjacency list.
  */
 Utils.fetchTestGraph = function(debuggerServerRoot, adjList) {
+    var url = debuggerServerRoot + '/test/graph';
+    var params = { adjList : adjList };
     return $.ajax({
         url : debuggerServerRoot + '/test/graph',
-        data : { adjList : adjList }
+        data : params, 
+        dataFilter : function(data) {
+            return {
+                code: data,
+                url : "{0}?{1}".format(url, $.param(params))
+            };
+        }
     });
 }
 


### PR DESCRIPTION
Last commit broke the capture scenario for integrity violation panel on the left. Fixed that. Also cleaned up the fetchTest function return values to use the dataFilter jQuery option rather than constructing custom objects.  
