### PR TITLE
Support TestGraph's edge value.

### DIFF
--- a/src/main/java/org/apache/giraph/debugger/mock/FormatHelper.java
+++ b/src/main/java/org/apache/giraph/debugger/mock/FormatHelper.java
@@ -1,0 +1,97 @@
+package org.apache.giraph.debugger.mock;
+
+import java.math.BigDecimal;
+import java.text.DecimalFormat;
+import java.util.Set;
+
+import org.apache.giraph.utils.WritableUtils;
+import org.apache.hadoop.io.BooleanWritable;
+import org.apache.hadoop.io.ByteWritable;
+import org.apache.hadoop.io.DoubleWritable;
+import org.apache.hadoop.io.FloatWritable;
+import org.apache.hadoop.io.IntWritable;
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.io.Writable;
+
+public class FormatHelper {
+
+  private final DecimalFormat decimalFormat = new DecimalFormat("#.#####");
+  
+  @SuppressWarnings("rawtypes")
+  private Set<Class> complexWritables;
+  
+  public FormatHelper() {
+  }
+  
+  @SuppressWarnings("rawtypes")
+  public FormatHelper(Set<Class> complexWritables) {
+    registerComplexWritableClassList(complexWritables);
+  }
+  
+  @SuppressWarnings("rawtypes")
+  public void registerComplexWritableClassList(Set<Class> complexWritables) {
+    this.complexWritables = complexWritables;
+  }
+
+  public String formatWritable(Writable writable) {
+    if (writable instanceof NullWritable) {
+      return "NullWritable.get()";
+    } else if (writable instanceof BooleanWritable) {
+      return String.format("new BooleanWritable(%s)", format(((BooleanWritable) writable).get()));
+    } else if (writable instanceof ByteWritable) {
+      return String.format("new ByteWritable(%s)", format(((ByteWritable) writable).get()));
+    } else if (writable instanceof IntWritable) {
+      return String.format("new IntWritable(%s)", format(((IntWritable) writable).get()));
+    } else if (writable instanceof LongWritable) {
+      return String.format("new LongWritable(%s)", format(((LongWritable) writable).get()));
+    } else if (writable instanceof FloatWritable) {
+      return String.format("new FloatWritable(%s)", format(((FloatWritable) writable).get()));
+    } else if (writable instanceof DoubleWritable) {
+      return String.format("new DoubleWritable(%s)", format(((DoubleWritable) writable).get()));
+    } else if (writable instanceof Text) {
+      return String.format("new Text(%s)", ((Text) writable).toString());
+    } else {
+      if (complexWritables != null)
+        complexWritables.add(writable.getClass());
+      String str = toByteArrayString(WritableUtils.writeToByteArray(writable));
+      return String.format("(%s)read%sFromByteArray(new byte[] {%s})", writable.getClass()
+          .getSimpleName(), writable.getClass().getSimpleName(), str);
+    }
+  }
+
+  public String format(Object input) {
+    if (input instanceof Boolean || input instanceof Byte || input instanceof Character
+        || input instanceof Short || input instanceof Integer) {
+      return input.toString();
+    } else if (input instanceof Long) {
+      return input.toString() + "l";
+    } else if (input instanceof Float) {
+      return decimalFormat.format(input) + "f";
+    } else if (input instanceof Double) {
+      double val = ((Double) input).doubleValue();
+      if (val == Double.MAX_VALUE)
+        return "Double.MAX_VALUE";
+      else if (val == Double.MIN_VALUE)
+        return "Double.MIN_VALUE";
+      else {
+        BigDecimal bd = new BigDecimal(val);
+        return bd.toEngineeringString() + "d";
+      }
+    } else {
+      return input.toString();
+    }
+  }
+
+  private String toByteArrayString(byte[] byteArray) {
+    StringBuilder strBuilder = new StringBuilder();
+    for (int i = 0; i < byteArray.length; i++) {
+      if (i != 0)
+        strBuilder.append(',');
+      strBuilder.append(Byte.toString(byteArray[i]));
+    }
+    return strBuilder.toString();
+  }
+
+}

--- a/src/main/java/org/apache/giraph/debugger/mock/TestGenerator.java
+++ b/src/main/java/org/apache/giraph/debugger/mock/TestGenerator.java
@@ -54,7 +54,7 @@ public abstract class TestGenerator extends VelocityBasedGenerator {
     }
 
     private void addHelper() {
-      context.put("helper", new FormatHelper());
+      context.put("helper", new FormatHelper(complexWritables));
     }
     
     private void addWritableReadFromString() {
@@ -115,69 +115,6 @@ public abstract class TestGenerator extends VelocityBasedGenerator {
         }
       }
       context.put("configs", configs);
-    }
-  }
-
-  public class FormatHelper {
-
-    private DecimalFormat decimalFormat = new DecimalFormat("#.#####");
-
-    public String formatWritable(Writable writable) {
-      if (writable instanceof NullWritable) {
-        return "NullWritable.get()";
-      } else if (writable instanceof BooleanWritable) {
-        return String.format("new BooleanWritable(%s)", format(((BooleanWritable) writable).get()));
-      } else if (writable instanceof ByteWritable) {
-        return String.format("new ByteWritable(%s)", format(((ByteWritable) writable).get()));
-      } else if (writable instanceof IntWritable) {
-        return String.format("new IntWritable(%s)", format(((IntWritable) writable).get()));
-      } else if (writable instanceof LongWritable) {
-        return String.format("new LongWritable(%s)", format(((LongWritable) writable).get()));
-      } else if (writable instanceof FloatWritable) {
-        return String.format("new FloatWritable(%s)", format(((FloatWritable) writable).get()));
-      } else if (writable instanceof DoubleWritable) {
-        return String.format("new DoubleWritable(%s)", format(((DoubleWritable) writable).get()));
-      } else if (writable instanceof Text) {
-        return String.format("new Text(%s)", ((Text) writable).toString());
-      } else {
-        complexWritables.add(writable.getClass());
-        String str = toByteArrayString(WritableUtils.writeToByteArray(writable));
-        return String.format("(%s)read%sFromByteArray(new byte[] {%s})", writable.getClass().getSimpleName(),
-            writable.getClass().getSimpleName(), str);
-      }
-    }
-
-    public String format(Object input) {
-      if (input instanceof Boolean || input instanceof Byte || input instanceof Character
-          || input instanceof Short || input instanceof Integer) {
-        return input.toString();
-      } else if (input instanceof Long) {
-        return input.toString() + "l";
-      } else if (input instanceof Float) {
-        return decimalFormat.format(input) + "f";
-      } else if (input instanceof Double) {
-        double val = ((Double) input).doubleValue();
-        if (val == Double.MAX_VALUE)
-          return "Double.MAX_VALUE";
-        else if (val == Double.MIN_VALUE)
-          return "Double.MIN_VALUE";
-        else {
-          BigDecimal bd = new BigDecimal(val);
-          return bd.toEngineeringString() + "d";
-        }
-      } else {
-        return input.toString();
-      }
-    }
-    
-    private String toByteArrayString(byte[] byteArray) {
-      StringBuilder strBuilder = new StringBuilder();
-      for (int i = 0; i < byteArray.length; i++) {
-        if (i != 0)
-          strBuilder.append(',');
-        strBuilder.append(Byte.toString(byteArray[i]));
-      }
-      return strBuilder.toString();
     }
   }
 }

--- a/src/main/java/org/apache/giraph/debugger/mock/TestGraphGenerator.java
+++ b/src/main/java/org/apache/giraph/debugger/mock/TestGraphGenerator.java
@@ -8,6 +8,8 @@ import java.util.Map;
 
 import org.apache.hadoop.io.DoubleWritable;
 import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.io.Writable;
 import org.apache.velocity.Template;
 import org.apache.velocity.VelocityContext;
 import org.apache.velocity.app.Velocity;
@@ -18,38 +20,60 @@ import org.apache.velocity.app.Velocity;
  * @author Brian Truong Ba Quan
  */
 public class TestGraphGenerator extends VelocityBasedGenerator {
-    
+
+  private enum WritableType {
+    NULL, LONG, DOUBLE
+  };
+
   public String generate(String[] inputStrs) throws IOException {
     VelocityContext context = buildContext(inputStrs);
-    
+
     try (StringWriter sw = new StringWriter()) {
       Template template = Velocity.getTemplate("TestGraphTemplate.vm");
       template.merge(context, sw);
       return sw.toString();
     }
   }
-  
+
   private VelocityContext buildContext(String[] inputStrs) {
     VelocityContext context = new VelocityContext();
+    context.put("helper", new FormatHelper());
     // Parse the string and check whether the inputs are integers or floating-point numbers
     String[][] tokens = new String[inputStrs.length][];
-    boolean isIdFloatingPoint = false;
-    boolean isValueFloatingPoint = false;
+    WritableType idWritableType = WritableType.NULL;
+    WritableType valueWritableType = WritableType.NULL;
+    WritableType edgeValueWritableType = WritableType.NULL;
     for (int i = 0; i < inputStrs.length; i++) {
       tokens[i] = inputStrs[i].trim().split("\\s+");
-      if (tokens[i].length >= 1)
-        isIdFloatingPoint |= isFloatingPoint(tokens[i][0]);
-      if (tokens[i].length >= 2)
-        isValueFloatingPoint |= isFloatingPoint(tokens[i][1]);
-      for (int j = 2; j < tokens[i].length; j++) {
-        isIdFloatingPoint |= isFloatingPoint(tokens[i][j]);
+      String[] nums = tokens[i][0].split(":");
+      WritableType type;
+      idWritableType =
+          ((type = parseWritableType(nums[0])).ordinal() > idWritableType.ordinal() ? type
+              : idWritableType);
+      if (nums.length > 1)
+        valueWritableType =
+            ((type = parseWritableType(nums[1])).ordinal() > valueWritableType.ordinal() ? type
+                : valueWritableType);
+
+      for (int j = 1; j < tokens[i].length; j++) {
+        nums = tokens[i][j].split(":");
+        idWritableType =
+            ((type = parseWritableType(nums[0])).ordinal() > idWritableType.ordinal() ? type
+                : idWritableType);
+        if (nums.length > 1)
+          edgeValueWritableType =
+              ((type = parseWritableType(nums[1])).ordinal() > edgeValueWritableType.ordinal() ? type
+                  : edgeValueWritableType);
       }
     }
     
     Map<Object, TemplateVertex> vertexMap = new LinkedHashMap<>(inputStrs.length);
+    String str;
     for (int i = 0; i < inputStrs.length; i++) {
-      Object id = convertToSuitableType(tokens[i][0], isIdFloatingPoint);
-      Object value = convertToSuitableType(tokens[i][1], isValueFloatingPoint);
+      String[] nums = tokens[i][0].split(":");
+      Object id = convertToSuitableType(nums[0], idWritableType);
+      str = nums.length > 1 ? nums[1] : "0";
+      Object value = convertToSuitableType(str, valueWritableType);
       TemplateVertex vertex = vertexMap.get(id);
       if (vertex == null) {
         vertex = new TemplateVertex(id);
@@ -57,68 +81,117 @@ public class TestGraphGenerator extends VelocityBasedGenerator {
       }
       vertex.setValue(value);
 
-      if (tokens[i].length > 2) {
-        for (int j = 2; j < tokens[i].length; j++) {
-          Object nbrId = convertToSuitableType(tokens[i][j], isIdFloatingPoint);
-          if (!vertexMap.containsKey(nbrId)) {
-            vertexMap.put(nbrId, new TemplateVertex(nbrId));
-          }
-          vertex.addNeighbor(nbrId);
+      for (int j = 1; j < tokens[i].length; j++) {
+        nums = tokens[i][j].split(":");
+        Object nbrId = convertToSuitableType(nums[0], idWritableType);
+        str = nums.length > 1 ? nums[1] : "0";
+        Object edgeValue = convertToSuitableType(str, edgeValueWritableType);
+        if (!vertexMap.containsKey(nbrId)) {
+          vertexMap.put(nbrId, new TemplateVertex(nbrId));
         }
+        vertex.addNeighbor(nbrId, edgeValue);
       }
     }
-    context.put("vertexIdClass", (isIdFloatingPoint ? DoubleWritable.class.getSimpleName()
-        : LongWritable.class.getSimpleName()));
-    context.put("vertexValueClass", (isValueFloatingPoint ? DoubleWritable.class.getSimpleName()
-        : LongWritable.class.getSimpleName()));
-    context.put("vertices", vertexMap);
     
+    updateContextByWritableType(context, "vertexIdClass", idWritableType);
+    updateContextByWritableType(context, "vertexValueClass", valueWritableType);
+    updateContextByWritableType(context, "edgeValueClass", edgeValueWritableType);
+    context.put("vertices", vertexMap);
+
     return context;
   }
-  
-  private boolean isFloatingPoint(String str) {
-    try {
-      Long.valueOf(str);
-      return false;
-    } catch (NumberFormatException ex) {
-      return true;
+
+  private WritableType parseWritableType(String str) {
+    if (str == null)
+      return WritableType.NULL;
+    else {
+      try {
+        Long.valueOf(str);
+        return WritableType.LONG;
+      } catch (NumberFormatException ex) {
+        return WritableType.DOUBLE;
+      }
     }
   }
-  
-  private String convertToSuitableType(String token, boolean isFloatingPoint) {
-    return (isFloatingPoint ? Double.valueOf(token).toString() + "d" :
-      Long.valueOf(token).toString() + "l");
+
+  private void updateContextByWritableType(VelocityContext context, String contextKey,
+      WritableType type) {
+    switch (type) {
+      case NULL:
+        context.put(contextKey, NullWritable.class.getSimpleName());
+        break;
+      case LONG:
+        context.put(contextKey, LongWritable.class.getSimpleName());
+        break;
+      case DOUBLE:
+        context.put(contextKey, DoubleWritable.class.getSimpleName());
+        break;
+      default:
+        throw new IllegalStateException("Unknown type!");
+    }
   }
-  
+
+  private Writable convertToSuitableType(String token, WritableType type) {
+    switch (type) {
+      case NULL:
+        return NullWritable.get();
+      case LONG:
+        return new LongWritable(Long.valueOf(token));
+      case DOUBLE:
+        return new DoubleWritable(Double.valueOf(token));
+      default:
+        throw new IllegalStateException("Unknown type!");
+    }
+  }
+
   public static class TemplateVertex {
     private Object id;
     private Object value;
-    private ArrayList<Object> neighbors;
-    
+    private ArrayList<TemplateNeighbor> neighbors;
+
     public TemplateVertex(Object id) {
       super();
       this.id = id;
       this.neighbors = new ArrayList<>();
     }
-    
+
     public Object getId() {
       return id;
     }
-    
+
     public Object getValue() {
       return value;
     }
-    
+
     public void setValue(Object value) {
       this.value = value;
     }
-    
-    public ArrayList<Object> getNeighbors() {
+
+    public ArrayList<TemplateNeighbor> getNeighbors() {
       return neighbors;
     }
-    
-    public void addNeighbor(Object nbrId) {
-      neighbors.add(nbrId);
+
+    public void addNeighbor(Object nbrId, Object edgeValue) {
+      neighbors.add(new TemplateNeighbor(nbrId, edgeValue));
+    }
+  }
+
+  public static class TemplateNeighbor {
+    private Object id;
+    private Object edgeValue;
+
+    public TemplateNeighbor(Object id, Object edgeValue) {
+      super();
+      this.id = id;
+      this.edgeValue = edgeValue;
+    }
+
+    public Object getId() {
+      return id;
+    }
+
+    public Object getEdgeValue() {
+      return edgeValue;
     }
   }
 }

--- a/src/main/resources/org/apache/giraph/debugger/mock/TestGraphTemplate.vm
+++ b/src/main/resources/org/apache/giraph/debugger/mock/TestGraphTemplate.vm
@@ -1,11 +1,10 @@
-    TestGraph<$vertexIdClass, $vertexValueClass, NullWritable> graph 
-         = new TestGraph<$vertexIdClass, $vertexValueClass, NullWritable>(new GiraphConfiguration());      
+    TestGraph<$vertexIdClass, $vertexValueClass, $edgeValueClass> graph 
+         = new TestGraph<>(new GiraphConfiguration());
+    graph      
 #foreach ($vertex in $vertices)
-#set ($edgeArrayName = "edges" + $foreach.index)
-    Entry<$vertexIdClass, NullWritable>[] $edgeArrayName = new Entry[$vertex.neighbors.size()];   
+    .addVertex($helper.formatWritable($vertex.id), $helper.formatWritable($vertex.value))
 #foreach ($neighbor in $vertex.neighbors)
-    $edgeArrayName#[[[]]#$foreach.index] = new SimpleEntry<$vertexIdClass, NullWritable>(
-         new $vertexIdClass($neighbor), NullWritable.get());
+    .addEdge($helper.formatWritable($vertex.id), $helper.formatWritable($neighbor.id), $helper.formatWritable($neighbor.edgeValue))
+#end 
 #end
-    graph.addVertex(new $vertexIdClass($vertex.id), new $vertexValueClass($vertex.value), $edgeArrayName);   
-#end
+    ;


### PR DESCRIPTION
Fixes #86

Input format: [vertexId]:[vertexValue] [neighborId1:edgeValue1] [neighborId2:edgeValue2] ....

Sample input: 
1:1.0 2:2.2 3:3.3
2:2.0 3:3.3
3:3.0 2:2.2

If all vertexValue or edgeValue are not provided, they are assumed as null, i.e., this input is also accepted with edgeValue as null:
1:1.0 2 3
2:2.0 3
3:3.0 2

When some vertexValue/edgeValue are provided and some are not provided, the missing ones are assumed to 0. That is,
1:1.0 2:2.2 3
2:2.0 3
3:3.0 2
is equivalent to
1:1.0 2:2.2 3:0
2:2.0 3:0
3:3.0 2:0
