### PR TITLE
Fixing #102 - Correcting Received Messages

### DIFF
--- a/src/main/resources/org/apache/giraph/debugger/gui/js/editor.core.js
+++ b/src/main/resources/org/apache/giraph/debugger/gui/js/editor.core.js
@@ -214,7 +214,7 @@ Editor.prototype.getMessagesReceivedByNode = function(id) {
 
     for (var i = 0; i < this.messages.length; i++) {
         var messageObj = this.messages[i];
-        if (messageObj.receiver.id === id && messageObj.incoming === true) {
+        if (messageObj.incoming === true && messageObj.receiver.id === id) {
             messagesReceived[dummyPrefix + i] = messageObj.message;
         }
     }


### PR DESCRIPTION
The bug was due to the fact that the GUI was not using the "incomingMessages" sent by the server. Instead it was using the sent messages to construct received messages as well. I have fixed it but there is a small issue - incomingMessages sent by the server do not have the senderID. I have fixed the bug by honoring incomingMessages from the debuggerServer but I had to use dummy sender IDs like v1, v2...Unfortunately I do not have the setup to test this right now :(. Friday is a little tight but might have some time tomorrow. The PR should give you an idea of what was going wrong. If this doesn't fix it or you need any help, let me know, I'll test tomorrow.
